### PR TITLE
Corrected URL reference to wrong Wikipedia page in JSON data

### DIFF
--- a/logic-timeline.json
+++ b/logic-timeline.json
@@ -748,7 +748,7 @@
 		"tag": "People",
                 "asset":
                 {
-                    "media":"http://en.wikipedia.org/wiki/John_Venn",
+                    "media":"http://en.wikipedia.org/wiki/Alfred_North_Whitehead",
                     "credit":"",
                     "caption":""
                 }


### PR DESCRIPTION
Now reads 'https://en.wikipedia.org/wiki/Alfred_North_Whitehead' instead of 'https://en.wikipedia.org/wiki/John_Venn'.